### PR TITLE
Adding jest for testing and fixing createSystem bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+test:
+	jest

--- a/lib/createSystem.js
+++ b/lib/createSystem.js
@@ -40,7 +40,7 @@ module.exports = function (systemName, cb) {
             },
             transform: function(read, write, file) {
               read
-                .pipe(replace(/\[SERVICE_NAME\]/g, name))
+                .pipe(replace(/\[SYSTEM_NAME\]/g, name))
                 .pipe(write);
             }
           },cb);

--- a/lib/createSystem.test.js
+++ b/lib/createSystem.test.js
@@ -1,0 +1,38 @@
+const exec = require('child_process').exec;
+const fs = require('fs')
+const path = require('path')
+
+// Replace hub.create with a mock noop
+jest.mock('./hub', () => ({create: function(args, options, cb) {
+  process.nextTick(function() { cb() })
+}}))
+
+const createSystem = require('./createSystem.js')
+
+describe('createSystem', function() {
+  it('can create a system', function (done) {
+    let testName = 'test-system-' + Date.now();
+
+    createSystem(testName, function(err) {
+      if (err) return done(err);
+
+      expect(fs.existsSync(path.join(testName, 'Makefile'))).toBeTruthy();
+
+      exec('rm -r ' + testName,  function() { done(); })
+    })
+  });
+
+  it('created system has valid tmuxinator config', function (done) {
+    let testName = 'test-system-' + Date.now();
+
+    createSystem(testName, function(err) {
+      if (err) return done(err);
+
+      const content = fs.readFileSync(path.join(testName, 'tmuxinator.all.yml'), 'utf-8');
+
+      expect(content.indexOf(testName) > -1, 'contains system name').toBeTruthy()
+
+      exec('rm -r ' + testName,  function() { done(); })
+    })
+  });
+})

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
     "stream-replace": "^1.0.0",
     "tabtab": "0.0.4"
   },
-  "repository": "git@github.com:mateodelnorte/microsvc.git"
+  "repository": "git@github.com:mateodelnorte/microsvc.git",
+  "devDependencies": {
+    "jest": "^20.0.4"
+  }
 }


### PR DESCRIPTION
Hello.

Noticed while trying out microsvc that the tmux config file wasn't being generated properly. Rather than hacking at it without a safety net, I started by adding Jest for testing. If you feel strongly about it, let me know and I'll revert back.

Turns out it was replacing the wrong string in in the ncp replace code.

Cheers.